### PR TITLE
Bug Fix - wrong_no_interrupt

### DIFF
--- a/PiBowl.py
+++ b/PiBowl.py
@@ -274,11 +274,6 @@ def wrong_no_interrupt():
 	bigString.set("")
 	bigLabel.config(bg=top.cget('bg'))
 	
-	if firstWrong:			#in case of both teams buzz in early, both wrong_no_interrupt
-		firstWrong=false
-	else:
-		firstWrong=true 
-	
 	wrong()
 
 def wrong():

--- a/PiBowl.py
+++ b/PiBowl.py
@@ -273,7 +273,12 @@ def wrong_no_interrupt():
 	
 	bigString.set("")
 	bigLabel.config(bg=top.cget('bg'))
-	firstWrong=False
+	
+	if firstWrong:			#in case of both teams buzz in early, both wrong_no_interrupt
+		firstWrong=false
+	else:
+		firstWrong=true 
+	
 	wrong()
 
 def wrong():


### PR DESCRIPTION
Team 1 buzzes in and interrupts, wrong, -5. Team 2 buzzes in and interrupts as well, and gets it wrong, but it wasn't an interruption. Needs to move to next question and NOT allow Team 1 to have a second chance. This fixes this problem.
